### PR TITLE
Add simple API extension to parse domain names with invalid characters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,7 +387,12 @@ impl List {
 
     /// Parses a domain using the list
     pub fn parse_domain(&self, domain: &str) -> Result<Domain> {
-        Domain::parse(domain, self)
+        Domain::parse(domain, self, true)
+    }
+
+    /// Parses a domain using the list but without verifying the validity as a domain name
+    pub fn parse_domain_relaxed(&self, domain: &str) -> Result<Domain> {
+        Domain::parse(domain, self, false)
     }
 
     /// Parses a host using the list
@@ -465,7 +470,7 @@ impl List {
 
 impl Host {
     fn parse(mut host: &str, list: &List) -> Result<Host> {
-        if let Ok(domain) = Domain::parse(host, list) {
+        if let Ok(domain) = Domain::parse(host, list, true) {
             return Ok(Host::Domain(domain));
         }
         if host.starts_with("[") 
@@ -641,8 +646,8 @@ impl Domain {
         }
     }
 
-    fn parse(domain: &str, list: &List) -> Result<Domain> {
-        if !Self::has_valid_syntax(domain) {
+    fn parse(domain: &str, list: &List, validate_domain_syntax: bool) -> Result<Domain> {
+        if validate_domain_syntax && !Self::has_valid_syntax(domain) {
             return Err(ErrorKind::InvalidDomain(domain.into()).into());
         }
         let input = domain;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -175,6 +175,22 @@ fn list_behaviour() {
         });
     });
 
+    rdescribe("a relaxed domain", |ctx| {
+        ctx.it("should allow extended characters", || {
+            let domains = vec![
+                "_tcp.example.com.",
+                "_telnet._tcp.example.com.",
+                "*.example.com.",
+                "ex!mple.com.",
+            ];
+            for domain in domains {
+                println!("{} should be valid", domain);
+                assert!(list.parse_domain_relaxed(domain).is_ok());
+            }
+            pass!()
+        });
+    });
+
     rdescribe("a host", |ctx| {
         ctx.it("can be an IPv4 address", || {
             assert!(list.parse_host("127.38.53.247").is_ok());


### PR DESCRIPTION
This tries to address
https://github.com/rushmorem/publicsuffix/issues/6

I tried to keep the API changes minimal, although I am not sure if the possibility to create `Domain` structs which are invalid is wanted, but it was the simplest way to implement it.

The validating could be made a bit more strict, by extending `Domain::has_valid_syntax()` to have a flag which ignores the regexset but performs the rest of the validation.