### PR TITLE
Fix panic in Domain::assemble caused by having a single label with trailing dot

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -668,7 +668,7 @@ impl Domain {
         if check_syntax && !Self::has_valid_syntax(domain) {
             return Err(ErrorKind::InvalidDomain(domain.into()).into());
         }
-        let input = domain;
+        let input = domain.trim_right_matches('.');
         let (domain, res) = domain_to_unicode(input);
         if let Err(errors) = res {
             return Err(ErrorKind::Uts46(errors).into());

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -89,8 +89,16 @@ fn list_behaviour() {
             assert!(list.parse_domain("example.com.").is_ok());
         });
 
-        ctx.it("should not allow more than 1 trailing dots", || {
+        ctx.it("should not allow more than 1 trailing dot", || {
             assert!(list.parse_domain("example.com..").is_err());
+        });
+
+        ctx.it("should allow a single label with a single trailing dot", || {
+            assert!(list.parse_domain("com.").is_ok());
+        });
+
+        ctx.it("should have the same result with or without the trailing dot", || {
+                assert_eq!(list.parse_domain("com.").unwrap(), list.parse_domain("com").unwrap());
         });
 
         ctx.it("should not have empty labels", || {
@@ -194,6 +202,10 @@ fn list_behaviour() {
                 let name = list.parse_dns_name(name).unwrap();
                 assert!(name.domain().is_none());
             }
+        });
+
+        ctx.it("should not allow more than 1 trailing dot", || {
+            assert!(list.parse_dns_name("example.com..").is_err());
         });
     });
 


### PR DESCRIPTION
Domain::find_match miscounts the labels as being 2, if there is a single
label with a trailing dot causing an index out of range panic.

Fixes https://github.com/rushmorem/publicsuffix/issues/8

I just double checked that it still errors for double trailing dots. For everything parsed with `parse_domain` the check in [line 668](https://github.com/rushmorem/publicsuffix/blob/10dfb0ead5365c3776907e92145b81c39ad2277f/src/lib.rs#L668) catches it. For `parse_dns_name` the [`to_ascii` method](https://github.com/rushmorem/publicsuffix/blob/10dfb0ead5365c3776907e92145b81c39ad2277f/src/lib.rs#L481) errors with a `TooShortForDns`.

It might make sense to replace the `?` with a `chain_err` and also convert it into `InvalidDomain`, but thats a different issue.