### PR TITLE
Improve error message for parsing invalid DnsName

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ use std::fmt;
 pub use errors::{Result, Error};
 
 use regex::RegexSet;
-use errors::ErrorKind;
+use errors::{ErrorKind, ResultExt};
 #[cfg(feature = "remote_list")]
 use native_tls::TlsConnector;
 use idna::{domain_to_unicode, uts46};
@@ -478,7 +478,9 @@ impl List {
     /// Parses any arbitrary string that can be used as a key in a DNS database
     pub fn parse_dns_name(&self, name: &str) -> Result<DnsName> {
         let mut dns_name = DnsName {
-            name: Domain::to_ascii(name)?,
+            name: Domain::to_ascii(name).chain_err(|| {
+                ErrorKind::InvalidDomain(name.into())
+            })?,
             domain: None,
         };
         if let Ok(mut domain) = Domain::parse(name, self, false) {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,7 @@
 extern crate rspec;
 
 use {List, request};
+use errors::ErrorKind;
 use self::rspec::context::rdescribe;
 
 #[test]
@@ -91,6 +92,10 @@ fn list_behaviour() {
 
         ctx.it("should not allow more than 1 trailing dot", || {
             assert!(list.parse_domain("example.com..").is_err());
+            match *list.parse_domain("example.com..").unwrap_err().kind() {
+                ErrorKind::InvalidDomain(ref domain) => assert_eq!(domain, "example.com.."),
+                _ => assert!(false),
+            }
         });
 
         ctx.it("should allow a single label with a single trailing dot", || {
@@ -206,6 +211,10 @@ fn list_behaviour() {
 
         ctx.it("should not allow more than 1 trailing dot", || {
             assert!(list.parse_dns_name("example.com..").is_err());
+            match *list.parse_dns_name("example.com..").unwrap_err().kind() {
+                ErrorKind::InvalidDomain(ref domain) => assert_eq!(domain, "example.com.."),
+                _ => assert!(false),
+            }
         });
     });
 


### PR DESCRIPTION
Includes tests for `parse_domain` and `parse_dns_name`.