### PR TITLE
Handle existing and non-existing single-label domains identical

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -642,9 +642,13 @@ impl Domain {
             }
         }
 
-        if suffix.is_none() && d_labels.len() > 1 && no_possible_matches_found {
+        if suffix.is_none() && d_labels.len() > 0 && no_possible_matches_found {
             suffix = Some(Self::assemble(input, 1));
-            registrable = Some(Self::assemble(input, 2));
+            registrable = if d_labels.len() > 1 {
+                Some(Self::assemble(input, 2))
+            } else {
+                None
+            };
         }
 
         Ok(Domain {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -97,6 +97,24 @@ fn list_behaviour() {
             assert!(list.parse_domain("com.").is_ok());
         });
 
+        ctx.it("should always have a suffix for single-label domains", || {
+            let domains = vec![
+                // real TLDs
+                "com",
+                "saarland",
+                "museum.",
+                // non-existant TLDs
+                "localhost",
+                "madeup",
+                "with-dot.",
+            ];
+            for domain in domains {
+                let res = list.parse_domain(domain).unwrap();
+                assert_eq!(res.suffix(), Some(domain.trim_right_matches('.')));
+                assert!(res.root().is_none());
+            }
+        });
+
         ctx.it("should have the same result with or without the trailing dot", || {
                 assert_eq!(list.parse_domain("com.").unwrap(), list.parse_domain("com").unwrap());
         });


### PR DESCRIPTION
Always return a suffix and an empty registrable/root.

Since I am just doing some little fixes I can also do https://github.com/rushmorem/publicsuffix/issues/10 :)