### PR TITLE
Upgrade to url v2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ remote_list = ["native-tls"]
 error-chain = "0.12"
 idna = "0.1"
 regex = "1.0"
-url = "1.7"
+url = "2.0"
 lazy_static = "1.0"
 
 [dependencies.native-tls]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,6 +18,8 @@ error_chain! {
 
         NoHost { }
 
+        NoPort { }
+
         InvalidHost { }
 
         InvalidEmail { }


### PR DESCRIPTION
The upgrade is mostly smooth, except support for converting a URL to
socket addresses has annoyingly been removed.