### PR TITLE
Avoid bringing backtrace as a dependency of error-chain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default = ["remote_list"]
 remote_list = ["native-tls"]
 
 [dependencies]
-error-chain = "0.12"
+error-chain = { version = "0.12", default-features = false }
 idna = "0.2"
 regex = "1.0"
 url = "2.0"


### PR DESCRIPTION
It's not being used at all by this library. Furthermore, backtrace gives
trouble when cross-compiling.