### PR TITLE
Track longest valid suffix seen

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -183,6 +183,16 @@ fn list_behaviour() {
             too_many_chars_domain.push_str(".com");
             assert!(list.parse_domain(&too_many_chars_domain).is_err());
         });
+
+        ctx.it("should choose the longest valid suffix", || {
+            let domain = list.parse_domain("foo.builder.nu").unwrap();
+            assert_eq!(Some("nu"), domain.suffix());
+            assert_eq!(Some("builder.nu"), domain.root());
+
+            let domain = list.parse_domain("foo.fbsbx.com").unwrap();
+            assert_eq!(Some("com"), domain.suffix());
+            assert_eq!(Some("fbsbx.com"), domain.root());
+        });
     });
 
     rdescribe("a DNS name", |ctx| {


### PR DESCRIPTION
When finding the suffix of an input domain, it was not remembering if it had ever encountered a valid suffix along the way, so when a shorter suffix matches, but then it partially matches another rule, it would erroneously find no suffix. For example, `cdn.fbsbx.com` should find the suffix of `com`, but because it partially matches the rule for `apps.fbsbx.com`, it finds no suffix or root domain.

This changes the suffix finding algorithm to remember the longest valid suffix it has seen and uses that.

Fixes #24