### PR TITLE
Don't assert known suffix for wildcard match

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -644,6 +644,7 @@ impl Domain {
 
         let mut current = &list.root;
         let mut s_labels_len = 0;
+        let mut wildcard_match = false;
 
         for label in domain.rsplit('.') {
             if let Some(child) = current.children.get(label) {
@@ -653,6 +654,7 @@ impl Domain {
                 // wildcard rule
                 current = child;
                 s_labels_len += 1;
+                wildcard_match = true;
             } else {
                 // no match rules
                 break;
@@ -665,7 +667,11 @@ impl Domain {
 
         match longest_valid {
             Some((leaf, suffix_len)) => {
-                let typ = Some(leaf.typ);
+                let typ = if !wildcard_match {
+                    Some(leaf.typ)
+                } else {
+                    None
+                };
 
                 let suffix_len = if leaf.is_exception_rule {
                     suffix_len - 1

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -193,6 +193,11 @@ fn list_behaviour() {
             assert_eq!(Some("com"), domain.suffix());
             assert_eq!(Some("fbsbx.com"), domain.root());
         });
+
+        ctx.it("should not indicate wildcard matched domains as having known suffix", || {
+            let domain = list.parse_domain("some.total.nonsensetld").unwrap();
+            assert!(!domain.has_known_suffix());
+        });
     });
 
     rdescribe("a DNS name", |ctx| {


### PR DESCRIPTION
Where the domain was only successfully matched by the wildcard match rule, we shouldn't assert that the domain has a known suffix, nor that it is definitely an ICANN or Private domain.

This could also arguably be applied to the 'registrable' portion of the Domain, given a wildcard only match tells us nothing about the registrability of the last token.

However since the registrable field is conflated with the root of the domain, we leave it alone so fewer changes are required elsewhere in the library.