### PR TITLE
Replace dependencies with local impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ default = ["remote_list"]
 remote_list = ["native-tls"]
 
 [dependencies]
-error-chain = { version = "0.12", default-features = false }
 idna = "0.2"
 url = "2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,7 @@ remote_list = ["native-tls"]
 [dependencies]
 error-chain = { version = "0.12", default-features = false }
 idna = "0.2"
-regex = { version = "1.0", default-features = false, features = ["std"] }
 url = "2.0"
-lazy_static = "1.0"
 
 [dependencies.native-tls]
 version = "0.2"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,42 +1,112 @@
 //! Errors returned by this library
 
+use std::fmt;
+use std::io;
+use url::ParseError;
+
 #[cfg(feature = "remote_list")]
 use std::net::TcpStream;
 
-error_chain! {
-    foreign_links {
-        Io(::std::io::Error);
-        Url(::url::ParseError);
-        Tls(::native_tls::Error) #[cfg(feature = "remote_list")];
-        Handshake(::native_tls::HandshakeError<TcpStream>) #[cfg(feature = "remote_list")];
+#[cfg(feature = "remote_list")]
+use native_tls::{Error as TlsError, HandshakeError};
+
+pub type Result<T> = ::std::result::Result<T, Error>;
+
+#[derive(Debug)]
+pub struct Error(
+    /// The kind of the error.
+    pub ErrorKind,
+);
+impl std::error::Error for Error {}
+
+impl Error {
+    pub fn kind(&self) -> &ErrorKind {
+        &self.0
     }
+}
 
-    errors {
-        UnsupportedScheme { }
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
-        InvalidList { }
+#[derive(Debug)]
+/// The kind of an error.
+pub enum ErrorKind {
+    Io(::std::io::Error),
+    Url(::url::ParseError),
+    #[cfg(feature = "remote_list")]
+    Tls(::native_tls::Error),
+    #[cfg(feature = "remote_list")]
+    Handshake(HandshakeError<TcpStream>),
+    /// A convenient variant for String.
+    Msg(String),
+    UnsupportedScheme,
+    InvalidList,
+    NoHost,
+    NoPort,
+    InvalidHost,
+    InvalidEmail,
+    InvalidRule(String),
+    InvalidDomain(String),
+    Uts46(::idna::Errors),
+    #[doc(hidden)]
+    __Nonexhaustive {},
+}
 
-        NoHost { }
-
-        NoPort { }
-
-        InvalidHost { }
-
-        InvalidEmail { }
-
-        InvalidRule(t: String) {
-            description("invalid rule")
-            display("invalid rule: '{}'", t)
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ErrorKind::Io(e) => write!(f, "{}", e),
+            ErrorKind::Url(e) => write!(f, "{}", e),
+            #[cfg(feature = "remote_list")]
+            ErrorKind::Tls(e) => write!(f, "{}", e),
+            #[cfg(feature = "remote_list")]
+            ErrorKind::Handshake(e) => write!(f, "{}", e),
+            ErrorKind::Msg(e) => write!(f, "{}", e),
+            ErrorKind::UnsupportedScheme => write!(f, "UnsupportedScheme"),
+            ErrorKind::InvalidList => write!(f, "InvalidList"),
+            ErrorKind::NoHost => write!(f, "NoHost"),
+            ErrorKind::NoPort => write!(f, "NoPort"),
+            ErrorKind::InvalidHost => write!(f, "InvalidHost"),
+            ErrorKind::InvalidEmail => write!(f, "InvalidEmail"),
+            ErrorKind::InvalidRule(t) => write!(f, "invalid rule: '{}'", t),
+            ErrorKind::InvalidDomain(t) => write!(f, "invalid domain: '{}'", t),
+            ErrorKind::Uts46(e) => write!(f, "UTS #46 processing error: '{:?}'", e),
+            ErrorKind::__Nonexhaustive {} => write!(f, "__Nonexhaustive"),
         }
+    }
+}
 
-        InvalidDomain(t: String) {
-            description("invalid domain")
-            display("invalid domain: '{}'", t)
-        }
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Self {
+        Error(kind)
+    }
+}
 
-        Uts46(t: ::idna::Errors) {
-            description("UTS #46 processing failed")
-            display("UTS #46 processing error: '{:?}'", t)
-        }
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Error(ErrorKind::Io(e))
+    }
+}
+
+impl From<ParseError> for Error {
+    fn from(e: url::ParseError) -> Self {
+        Error(ErrorKind::Url(e))
+    }
+}
+
+#[cfg(feature = "remote_list")]
+impl From<TlsError> for Error {
+    fn from(e: TlsError) -> Self {
+        Error(ErrorKind::Tls(e))
+    }
+}
+
+#[cfg(feature = "remote_list")]
+impl From<HandshakeError<TcpStream>> for Error {
+    fn from(e: HandshakeError<TcpStream>) -> Self {
+        Error(ErrorKind::Handshake(e))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,8 +60,6 @@
 
 #![recursion_limit = "1024"]
 
-#[macro_use]
-extern crate error_chain;
 #[cfg(feature = "remote_list")]
 extern crate native_tls;
 extern crate idna;
@@ -91,7 +89,7 @@ use std::fmt;
 
 pub use errors::{Result, Error};
 
-use errors::{ErrorKind, ResultExt};
+use errors::ErrorKind;
 #[cfg(feature = "remote_list")]
 use native_tls::TlsConnector;
 use idna::{domain_to_unicode};
@@ -483,7 +481,7 @@ impl List {
     /// Parses any arbitrary string that can be used as a key in a DNS database
     pub fn parse_dns_name(&self, name: &str) -> Result<DnsName> {
         let mut dns_name = DnsName {
-            name: Domain::to_ascii(name).chain_err(|| {
+            name: Domain::to_ascii(name).map_err(|_| {
                 ErrorKind::InvalidDomain(name.into())
             })?,
             domain: None,

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -1,12 +1,16 @@
 /// Check if input is a valid domain label
 pub fn is_label(input: &str) -> bool {
-    if input.is_empty() {
-        return false;
-    }
     let mut chars = input.chars();
 
+    // we need at least one char
+    let first = match chars.next() {
+        None => {
+            return false;
+        }
+        Some(c) => c,
+    };
+
     // it can start with an alphanumeric character
-    let first = chars.next().unwrap();
     if !first.is_ascii_alphanumeric() {
         return false;
     }
@@ -26,16 +30,18 @@ pub fn is_label(input: &str) -> bool {
 
 /// Check the local part of an email address (before @)
 pub fn is_email_local(input: &str) -> bool {
-    if input.is_empty() {
-        return false;
-    }
-
     let mut chars = input.chars();
 
-    let first = chars.next().unwrap();
+    // we need at least one char
+    let first = match chars.next() {
+        None => {
+            return false;
+        }
+        Some(c) => c,
+    };
 
     let last_index = input.len() - 2.min(input.len());
-    if first == ' '{
+    if first == ' ' {
         return false;
     } else if first == '"' {
         // quoted

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -1,0 +1,160 @@
+/// Check if input is a valid domain label
+pub fn is_label(input: &str) -> bool {
+    if input.is_empty() {
+        return false;
+    }
+    let mut chars = input.chars();
+
+    // it can start with an alphanumeric character
+    let first = chars.next().unwrap();
+    if !first.is_ascii_alphanumeric() {
+        return false;
+    }
+
+    // then optionally be followed by any combination of
+    // alphanumeric characters and dashes
+    let last_index = input.len() - 2.min(input.len());
+    for (index, c) in chars.enumerate() {
+        // before finally ending with an alphanumeric character
+        if !c.is_ascii_alphanumeric() && (index == last_index || c != '-') {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Check the local part of an email address (before @)
+pub fn is_email_local(input: &str) -> bool {
+    if input.is_empty() {
+        return false;
+    }
+
+    let mut chars = input.chars();
+
+    let first = chars.next().unwrap();
+
+    let last_index = input.len() - 2.min(input.len());
+    if first == ' '{
+        return false;
+    } else if first == '"' {
+        // quoted
+        if input.len() == 1 {
+            return false;
+        }
+        for (index, c) in chars.enumerate() {
+            if index == last_index {
+                if c != '"' {
+                    return false;
+                }
+            } else {
+                if !is_combined(c) && !is_quoted(c) {
+                    return false;
+                }
+            }
+        }
+    } else {
+        // not quoted
+        if first == '.' {
+            return false;
+        }
+        for (index, c) in chars.enumerate() {
+            if !is_combined(c) && (index == last_index || c != '.') {
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
+// these characters can be anywhere in the expresion
+// [[:alnum:]!#$%&'*+/=?^_`{|}~-]
+fn is_global(c: char) -> bool {
+    c.is_ascii_alphanumeric()
+        || c == '-'
+        || c == '!'
+        || c == '#'
+        || c == '$'
+        || c == '%'
+        || c == '&'
+        || c == '\''
+        || c == '*'
+        || c == '+'
+        || c == '/'
+        || c == '='
+        || c == '?'
+        || c == '^'
+        || c == '_'
+        || c == '`'
+        || c == '{'
+        || c == '|'
+        || c == '}'
+        || c == '~'
+}
+fn is_non_ascii(c: char) -> bool {
+    c as u32 > 0x7f // non-ascii characters (can also be unquoted)
+}
+fn is_quoted(c: char) -> bool {
+    // ["(),\\:;<>@\[\]. ]
+    c == '"'
+        || c == '.'
+        || c == ' '
+        || c == '('
+        || c == ')'
+        || c == ','
+        || c == '\\'
+        || c == ':'
+        || c == ';'
+        || c == '<'
+        || c == '>'
+        || c == '@'
+        || c == '['
+        || c == ']'
+}
+fn is_combined(c: char) -> bool {
+    is_global(c) || is_non_ascii(c)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn is_label_correct() {
+        for l in &["a", "ab", "a-b", "a--b", "0Z"] {
+            assert!(is_label(l));
+        }
+    }
+
+    #[test]
+    fn is_label_incorrect() {
+        for l in &["", "-", "a-", "-b", "$"] {
+            assert!(!is_label(l));
+        }
+    }
+
+    #[test]
+    fn is_email_local_correct() {
+        for l in &[
+            "a",
+            "ab",
+            "a.b",
+            "a\u{0080}",
+            "$",
+            "\"\"\"",
+            "\"a b\"",
+            "\" \"",
+            "\"a<>@\"",
+        ] {
+            assert!(is_email_local(l));
+        }
+    }
+
+    #[test]
+    fn is_email_local_incorrect() {
+        for l in &["", " a", "a ", "a.", ".b", "a\x7f", "\"", "\"a", "a\""] {
+            assert!(!is_email_local(l));
+        }
+    }
+}


### PR DESCRIPTION
Hi! I'm looking at using publicsuffix in [hreq](https://github.com/algesten/hreq). In hreq I want to minimize the number of dependencies and after some [investigation](https://github.com/algesten/hreq/issues/2) into dependencies that are pulled in for one crate only, I found that publicsuffix was a good candidate.

Looking at publicsuffix dependencies, I figured both `error-chain` and `regex` could quite easily be replaced by local implementations.

This PR is broken into two commits:

* The first removes the need for `regex` and `lazy_static` and uses a simple iterator approach to validate domain names and email local parts.
* The second removes `error-chain` by making a hand written impl of `Error`.

The second commit might be controversial cause it changes the surface area API of the `Error` type – i.e. breaking change. Happy to discuss/work the commits separately or as one.

```
├── publicsuffix v1.5.4
│   ├── error-chain v0.12.2
│   │   [build-dependencies]
│   │   └── version_check v0.9.1
│   ├── idna v0.2.0
│   │   ├── matches v0.1.8
│   │   ├── unicode-bidi v0.3.4
│   │   │   └── matches v0.1.8 (*)
│   │   └── unicode-normalization v0.1.12
│   │       └── smallvec v1.4.0
│   ├── lazy_static v1.4.0
│   ├── regex v1.3.7
│   │   └── regex-syntax v0.6.17
│   └── url v2.1.1
│       ├── idna v0.2.0 (*)
│       ├── matches v0.1.8 (*)
│       └── percent-encoding v2.1.0 (*)
```